### PR TITLE
README: update fzf script

### DIFF
--- a/README
+++ b/README
@@ -66,9 +66,10 @@ for selecting the secret.
     #! /usr/bin/env bash
     set -eou pipefail
     PREFIX="${PASSAGE_DIR:-$HOME/.passage/store}"
+    FZF_DEFAULT_OPTS=""
     name="$(find "$PREFIX" -type f -name '*.age' | \
       sed -e "s|$PREFIX/||" -e 's|\.age$||' | \
-      fzf --height 40% --reverse)"
+      fzf --height 40% --reverse --no-multi)"
     passage "${@}" "$name"
 
 Migrating from pass


### PR DESCRIPTION
This PR proposes some minor tweaks to the way fzf is being called. 
- By emptying `FZF_DEFAULT_OPTS=""` we make sure the interface is clean, doesn't have any styling and doesn't have features enabled that don't work. For example the `--preview`  would not add much value on the plain `.age` files.
- By default fzf has the ability to select multiple entries and pass them to whatever you're doing.
In passage's case this doesn't work - passage can only decrypt one item per invocation (at least this is what I've gathered from testing). So the argument `--no-multi` disables multi selection improving UX
- The other arguments just add some usage and general information what's going on - this is just something I'd personally added. Happy to remove it again. Below are some screenshots with and without it using the other changes mentioned above.

![example](https://user-images.githubusercontent.com/7935536/155415539-36934996-f664-4a42-b938-ab0e45f11054.png)

![example2](https://user-images.githubusercontent.com/7935536/155415541-c55b6e94-d2bb-4931-a997-79a3b44b430a.png)

Also I'm totally ok with you not accepting this PR at all :)