### PR TITLE
Remove extraneous endif in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ ifneq ($(strip $(wildcard $(ZSHCOMPDIR))),)
 WITH_ZSHCOMP := yes
 endif
 endif
-endif
 
 all:
 	@echo "Passage is a shell script, so there is nothing to do. Try \"make install\" instead."


### PR DESCRIPTION
Sorry, totally careless oversight on my part in the last commit, forgot to amend this change. `make install` fails without it.