### PR TITLE
README: use safer/better fzf script

### DIFF
--- a/README
+++ b/README
@@ -65,9 +65,11 @@ for selecting the secret.
     set -eou pipefail
     PREFIX="${PASSAGE_DIR:-$HOME/.passage/store}"
     FZF_DEFAULT_OPTS=""
-    name="$(find "$PREFIX" -type f -name '*.age' | \
-      sed -e "s|$PREFIX/||" -e 's|\.age$||' | \
-      fzf --height 40% --reverse --no-multi)"
+    name="$(cd "$PREFIX"; find . -type f -name '*.age' -exec sh -c '
+      for f do
+        f=${f#./}; printf "%s\n" "${f%.age}"
+      done
+    ' sh-find {} + | fzf --height 40% --reverse --no-multi)"
     passage "${@}" "$name"
 
 Migrating from pass


### PR DESCRIPTION
The current script has some drawbacks:

 - It spawns a sed command for each .age file.
 - If "$PREFIX" contains newline, sed command won't work correctly.
 - Using "$PREFIX" as pattern may lead to code injection.

Fixing those things are simple:

 - cd to "$PREFIX" before running find, we do this in subshell, so no effect to the current shell.
 - Use "find ... -exec sh -c '' sh-find {} +" form, so we can process as much as possible for each exec sh.
 - Use parameter expansion for stripping "./" prefix and ".age" suffix.

The script is now safer, maybe faster, and guarantee to work in all POSIX shells.