### PR TITLE
Fix Setup of diff.age.textconv

### DIFF
--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -570,7 +570,7 @@ cmd_git() {
 		echo '*.age diff=age' > "$PREFIX/.gitattributes"
 		git_add_file .gitattributes "Configure git repository for age file diff."
 		git -C "$INNER_GIT_DIR" config --local diff.age.binary true
-		git -C "$INNER_GIT_DIR" config --local diff.age.textconv "$AGE -d ${AGE_IDENTITY_ARGS[@]}"
+		git -C "$INNER_GIT_DIR" config --local diff.age.textconv "$AGE -d -i ${IDENTITIES_FILE}"
 	elif [[ -n $INNER_GIT_DIR ]]; then
 		tmpdir nowarn #Defines $SECURE_TMPDIR. We don't warn, because at most, this only copies encrypted files.
 		export TMPDIR="$SECURE_TMPDIR"


### PR DESCRIPTION
While I'm not 100% sure if that change fits your intentions, it does make ```passage git diff``` work for me, whereas the current implementation does nothing when that command is invoked.